### PR TITLE
Show that \r\n based line-endings also work.

### DIFF
--- a/test.js
+++ b/test.js
@@ -30,6 +30,16 @@ tape('compile multiple lines', function(t) {
   t.end()
 })
 
+tape('compile multiple lines with \\r', function(t) {
+  var filter = ignore.compile('a\r\nb\nc\r\nd');
+  t.ok(filter('a'))
+  t.ok(filter('b'))
+  t.ok(filter('c'))
+  t.ok(filter('d'))
+  t.notOk(filter('e'))
+  t.end()
+})
+
 tape('gitignore glob style', function(t) {
   var filter = ignore.compile('test')
   t.ok(filter('test'))
@@ -60,5 +70,4 @@ tape('comments', function(t) {
   t.notOk(filter('test'))
   t.notOk(filter('foo/test'))
   t.end()
-
 })


### PR DESCRIPTION
In reading the code I learned something about JavaScript: `String.prototype.trim` will remove line-endings like `\r`. To learn this I wrote what I thought would be a failing test, but it wasn't!

So ... here's test coverage for `\r\n` based line endings.
